### PR TITLE
fix: sync flow version in .flowconfig with yarn installed version

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -22,4 +22,4 @@ suppress_type=$FixMe
 experimental.lsp.code_actions=true
 
 [version]
-^0.107.0
+^0.110.1


### PR DESCRIPTION
In https://github.com/flow/flow-for-vscode/commit/6264fc249369913c290f1fe5c2ea05f17fa3d3c3 we upgraded flow to `0.110.1` but didn't update the `.flowconfig` version.

VSCode exception:

```
[Error - 6:49:18 PM - flow-for-vscode/.flowconfig] Failed to start flow
Error: Wrong version of Flow. The config specifies version ^0.107.0 but this is version 0.110.1
```